### PR TITLE
Windowsで起動時にUnicodeDecodeErrorが出るバグを修正した。

### DIFF
--- a/src/util.py
+++ b/src/util.py
@@ -20,7 +20,7 @@ z2h = str.maketrans(z_texts, h_texts)
 def load_json(file, path=current_path):
     fullPath = path + "/" + file + ".json"
     # print("loading:", fullPath)
-    with open(fullPath, "r") as fin:
+    with open(fullPath, "r", encoding='utf-8') as fin:
         return json.loads(fin.read())
 
 
@@ -28,13 +28,13 @@ def load_json(file, path=current_path):
 def save_json(file, data, path=current_path):
     fullPath = path + "/" + file + ".json"
     # print("saved to", fullPath)
-    with open(fullPath, "w") as fout:
+    with open(fullPath, "w", encoding='utf-8') as fout:
         fout.write(data)
 
 
 # テキストファイルロード
 def load_texts(file):
-    with open(current_path + "/" + file, "r") as fin:
+    with open(current_path + "/" + file, "r", encoding='utf-8') as fin:
         return fin.read().splitlines()
 
 


### PR DESCRIPTION
こんにちは
Windowsローカルモードで起動時にJSONのdecodeエラーが出て正常に起動できない問題を修正しました。

もしよろしかったら取り込んでください。

pyxel runやpyxel playで起動時にJSONの読み込みの箇所で以下のようなエラーが出る問題の修正です。
```
UnicodeDecodeError: 'cp932' codec can't decode byte 0x97 in position 40: illegal multibyte sequence
```